### PR TITLE
Wonhyeon/feat/make list page

### DIFF
--- a/src/components/IdolCircle.jsx
+++ b/src/components/IdolCircle.jsx
@@ -17,6 +17,5 @@ const IdolCircleImg = styled.img`
 //size 속성을 통해 크기를 동적으로 조정할 수 있게 했습니다.
 export default function IdolCircle({ idol, size }) {
   const { profilePicture, name } = { ...idol };
-  console.log(profilePicture);
   return <IdolCircleImg src={profilePicture} alt={name} size={size} />;
 }

--- a/src/components/IdolHorizontalCard.jsx
+++ b/src/components/IdolHorizontalCard.jsx
@@ -29,7 +29,6 @@ export const IdolHorizontalCardDiv = styled.div`
 
 export default function IdolHorizontalCard({ idol, flex, idx }) {
   const rank = idx + 1;
-  console.log(flex);
   return (
     <IdolHorizontalCardDiv>
       <IdolCircle idol={idol} size={"70px"} />

--- a/src/pages/list/ListPage.jsx
+++ b/src/pages/list/ListPage.jsx
@@ -4,15 +4,31 @@ import styled from "styled-components";
 import CreditInfo from "./components/CreditInfo";
 import DonationList from "./container/DonationList";
 import IdolCharts from "./components/IdolCharts";
+import media from "../../utils/mediaHelper";
+
+const Wrap = styled.div`
+  max-width: 1248px;
+  width: 100%;
+  margin: 0 auto;
+`;
 
 const Header = styled.header`
+  position: relative;
   top: 0;
   left: 0;
   width: 100%;
   height: 88px;
+  margin: 0 auto;
   padding-top: 44px;
   display: flex;
   align-items: center;
+  ${media.tablet`
+    height: 81px;
+    padding: 0;`}
+  ${media.desktop`
+    height: 80px;
+
+    `}
 `;
 
 const Logo = styled.a`
@@ -21,6 +37,14 @@ const Logo = styled.a`
   & img {
     width: 100%;
   }
+  ${media.tablet`
+    & img {
+    width: 120px;
+    height: auto;}`}
+  ${media.desktop`
+    & img {
+    width: auto;
+    height: 32px;}`}
 `;
 
 const Profile = styled.a`
@@ -39,7 +63,7 @@ const Profile = styled.a`
 
 export default function ListPage() {
   return (
-    <>
+    <Wrap>
       <Header>
         <Logo href="/abc">
           <img src={logoImg} />
@@ -51,6 +75,6 @@ export default function ListPage() {
       <CreditInfo />
       <DonationList />
       <IdolCharts />
-    </>
+    </Wrap>
   );
 }

--- a/src/pages/list/components/ChartTable.jsx
+++ b/src/pages/list/components/ChartTable.jsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import IdolHorizontalCard from "../../../components/IdolHorizontalCard";
 import { useEffect, useState } from "react";
-import { fetchChartDataByGender, fetchGetIdols } from "../../../utils/idolApi";
+import { fetchChartDataByGender } from "../../../utils/idolApi";
 
 const Table = styled.div`
   width: 100%;
@@ -60,14 +60,12 @@ export default function ChartTable() {
     <Table isGender={selectedGender}>
       <div className="chartHeader">
         <MenuComp
-          className="chartTab"
           active={selectedGender === "female"}
           onClick={() => handleGenderClick("female")}
         >
           이달의 여자 아이돌
         </MenuComp>
         <MenuComp
-          className="chartTab"
           active={selectedGender === "male"}
           onClick={() => handleGenderClick("male")}
         >

--- a/src/pages/list/components/ChartTable.jsx
+++ b/src/pages/list/components/ChartTable.jsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import IdolHorizontalCard from "../../../components/IdolHorizontalCard";
 import { useEffect, useState } from "react";
-import { fetchGetIdols } from "../../../utils/idolApi";
+import { fetchChartDataByGender, fetchGetIdols } from "../../../utils/idolApi";
 
 const Table = styled.div`
   width: 100%;
@@ -47,13 +47,13 @@ export default function ChartTable() {
   };
 
   useEffect(() => {
-    const getIdolListData = async () => {
-      const { list } = await fetchGetIdols();
-      setIdols(list);
+    const getChartListData = async () => {
+      const { idols } = await fetchChartDataByGender(selectedGender, {});
+      setIdols(idols);
       return;
     };
 
-    getIdolListData();
+    getChartListData();
   }, [selectedGender]);
 
   return (

--- a/src/pages/list/components/ChartTable.jsx
+++ b/src/pages/list/components/ChartTable.jsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import IdolHorizontalCard from "../../../components/IdolHorizontalCard";
 import { useEffect, useState } from "react";
 import { fetchChartDataByGender } from "../../../utils/idolApi";
+import media from "../../../utils/mediaHelper";
 
 const Table = styled.div`
   width: 100%;
@@ -36,6 +37,10 @@ const OrderedList = styled.ol`
   & li:last-child {
     border: none;
   }
+  ${media.desktop`
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    `}
 `;
 
 export default function ChartTable() {

--- a/src/pages/list/components/CreditInfo.jsx
+++ b/src/pages/list/components/CreditInfo.jsx
@@ -1,17 +1,16 @@
 import styled from "styled-components";
 import creditIc from "../../../assets/icon/ic_credit.png";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import media from "../../../utils/mediaHelper";
 
-const CreditInfoWrap = styled.div`
-  max-width: 1248px;
-  width: 100%;
-  margin: 0 auto;
+const WrapCredit = styled.div`
   padding: 0 24px;
 `;
 
 const CreditInfoDiv = styled.div`
   max-width: 1200px;
   width: 100%
+  height: 100%;
   margin: 0 auto;
   margin-top: 16px;
   padding: 20px;
@@ -20,16 +19,29 @@ const CreditInfoDiv = styled.div`
   align-items:center;
   border: 1px solid #F1EEF9CC;
   border-radius: 8px;
+  ${media.tablet`
+    margin-top:0;
+    padding: 35px 64px;
+    `}
+  ${media.desktop`
+    margin-top: 50px;
+    padding: 45px 78px;`}
 `;
 
 const InnerDiv = styled.div`
   display: flex;
   flex-direction: column;
   gap: 8px;
+  ${media.desktop`
+    gap: 16px;`}
 `;
 
 const Text = styled.p`
   color: #ffffff99;
+  ${media.tablet`
+    font-size:14px`}
+  ${media.desktop`
+      font-size: 16px;`}
 `;
 
 const Credit = styled.p`
@@ -42,6 +54,9 @@ const Credit = styled.p`
   & img {
     height: 16px;
   }
+  ${media.desktop`
+      font-size: 32px;
+  `}
 `;
 
 const ChargeLink = styled.a`
@@ -53,13 +68,20 @@ const ChargeLink = styled.a`
     cursor: pointer;
     text-decoration: none;
   }
+  ${media.desktop`
+      font-size: 24px;`}
 `;
 
 export default function CreditInfo() {
   const [credit, setCredit] = useState("36,000");
 
+  useEffect(() => {
+    const localCredit = localStorage.getItem("credit");
+    setCredit(localCredit);
+  }, []);
+
   return (
-    <CreditInfoWrap>
+    <WrapCredit>
       <CreditInfoDiv>
         <InnerDiv>
           <Text>내 크레딧</Text>
@@ -70,6 +92,6 @@ export default function CreditInfo() {
         </InnerDiv>
         <ChargeLink>충전하기</ChargeLink>
       </CreditInfoDiv>
-    </CreditInfoWrap>
+    </WrapCredit>
   );
 }

--- a/src/pages/list/components/CreditInfo.jsx
+++ b/src/pages/list/components/CreditInfo.jsx
@@ -73,11 +73,11 @@ const ChargeLink = styled.a`
 `;
 
 export default function CreditInfo() {
-  const [credit, setCredit] = useState("36,000");
+  const [credit, setCredit] = useState();
 
   useEffect(() => {
     const localCredit = localStorage.getItem("credit");
-    setCredit(localCredit);
+    setCredit(localCredit || "36,000");
   }, []);
 
   return (

--- a/src/pages/list/components/Donation.jsx
+++ b/src/pages/list/components/Donation.jsx
@@ -1,6 +1,7 @@
 import { styled } from "styled-components";
 import creditImg from "../../../assets/icon/ic_credit.png";
 import donationImgCover from "../../../assets/images/cover_donation.svg";
+import media from "../../../utils/mediaHelper";
 
 const DonationCard = styled.div`
   max-width: 282px;
@@ -10,6 +11,9 @@ const DonationCard = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
+  ${media.tablet`
+    width:282px;
+    height: 402px;`}
 `;
 
 const DonationImgWrapper = styled.div`
@@ -18,11 +22,15 @@ const DonationImgWrapper = styled.div`
   height: 206px;
   border-radius: 8px;
   overflow: hidden;
+  ${media.tablet`
+    width:282px;
+    height:293px;`}
 `;
 
 const DonationImg = styled.img`
   width: 100%;
   height: 100%;
+  object-fit: cover;
 `;
 
 const CoverImg = styled.img`
@@ -35,11 +43,11 @@ const CoverImg = styled.img`
 
 const DonateBtn = styled.button`
   position: absolute;
-  left: 8px;
+  left: 50%;
   bottom: 8px;
+  transform: translate(-50%);
   z-index: 2;
   width: 142px;
-  margin: 0 auto;
   padding: 2 48px;
   border-radius: 3px;
   font-size: 13px;
@@ -48,11 +56,14 @@ const DonateBtn = styled.button`
   letter-spacing: 2%;
   background: linear-gradient(to right, #f86f65, #fe5493);
   color: #ffffff;
+  ${media.tablet`
+    width: 234px;
+    height: 40px;`}
 `;
 
 const DonationDescription = styled.div`
-  width: 158px;
-  height: 87px;
+  width: 100%;
+  height: auto;
   padding: 0 2px;
   & h3 {
     font-weight: 400;
@@ -92,7 +103,7 @@ const TextSpan = styled.span`
 
 const ProgressBar = styled.div`
   position: relative;
-  width: 154px;
+  width: 100%;
   height: 1px;
   margin-top: 7px;
   border-radius: 1px;

--- a/src/pages/list/components/IdolCharts.jsx
+++ b/src/pages/list/components/IdolCharts.jsx
@@ -7,7 +7,7 @@ const ChartWrapper = styled.div`
   padding: 0 24px;
   color: #ffffff;
   & .header {
-    width: 327px;
+    width: 100%;
     height: 32px;
     display: flex;
     justify-content: space-between;

--- a/src/pages/list/container/DonationList.jsx
+++ b/src/pages/list/container/DonationList.jsx
@@ -1,14 +1,15 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import Donation from "../components/Donation";
 import { fetchGetDonations } from "../../../utils/donationApi";
 import { styled } from "styled-components";
+import media from "../../../utils/mediaHelper";
 
 const DonationFlexListWrap = styled.div`
   margin-top: 40px;
-  padding-left: 24px;
   & h1 {
     font-size: 16px;
     font-weight: 700;
+    margin-left: 24px;
     color: #f7f7f8;
   }
 `;
@@ -20,11 +21,6 @@ const DonationFlexList = styled.ul`
   overflow-x: auto;
   -ms-overflow-style: none; //여기부터
   scrollbar-width: none;
-  transition: margin-left 0.1s ease;
-  ${({ isScrolled }) =>
-    isScrolled &&
-    `
-    margin-left: -20px;`}
   &::-webkit-scrollbar {
     display: none; // 여기까지 스크롤바 없애는 속성
   }
@@ -35,21 +31,11 @@ const DonationLi = styled.li`
 `;
 
 const RightDiv = styled.div`
-  min-width: 24px;
+  min-width: 16px;
 `;
 
 export default function DonationList() {
   const [donations, setDonations] = useState([]);
-  const [isScrolled, setIsScrolled] = useState(false);
-  const scrollRef = useRef(null);
-
-  const handleScroll = () => {
-    if (scrollRef.current.scrollLeft > 0 && !isScrolled) {
-      setIsScrolled(true);
-    } else if (scrollRef.current.scrollLeft === 0 && isScrolled) {
-      setIsScrolled(false);
-    }
-  };
 
   useEffect(() => {
     const getDonationListData = async () => {
@@ -63,17 +49,14 @@ export default function DonationList() {
   return (
     <DonationFlexListWrap>
       <h1>후원을 기다리는 조공</h1>
-      <DonationFlexList
-        ref={scrollRef}
-        onScroll={handleScroll}
-        isScrolled={isScrolled}
-      >
+      <DonationFlexList>
+        <RightDiv />
         {donations.map((donation) => (
           <DonationLi key={donation.id}>
             <Donation donation={donation} />
           </DonationLi>
         ))}
-        <RightDiv></RightDiv>
+        <RightDiv />
       </DonationFlexList>
     </DonationFlexListWrap>
   );

--- a/src/pages/list/container/DonationList.jsx
+++ b/src/pages/list/container/DonationList.jsx
@@ -3,9 +3,14 @@ import Donation from "../components/Donation";
 import { fetchGetDonations } from "../../../utils/donationApi";
 import { styled } from "styled-components";
 import media from "../../../utils/mediaHelper";
+import leftBtnImg from "../../../assets/icon/btn_pagination_arrow_left.svg";
+import rightBtnImg from "../../../assets/icon/btn_pagination_arrow_right.svg";
 
 const DonationFlexListWrap = styled.div`
+  position: relative;
+  overflow: visible;
   margin-top: 40px;
+  padding: 0 24px;
   & h1 {
     font-size: 16px;
     font-weight: 700;
@@ -24,6 +29,10 @@ const DonationFlexList = styled.ul`
   &::-webkit-scrollbar {
     display: none; // 여기까지 스크롤바 없애는 속성
   }
+  ${media.tablet`
+      gap:16px;`}
+  ${media.desktop`
+        gap:24px;`}
 `;
 
 const DonationLi = styled.li`
@@ -32,10 +41,31 @@ const DonationLi = styled.li`
 
 const RightDiv = styled.div`
   min-width: 16px;
+  margin-left: -16px;
 `;
+
+const LeftButton = styled.button`
+  position: absolute;
+  top: 170px;
+  left: -40px;
+  cursor: pointer;
+`;
+
+const RightButton = styled.button`
+  position: absolute;
+  top: 170px;
+  right: -40px;
+  cursor: pointer;
+`;
+
+const itemsPerPage = 4;
 
 export default function DonationList() {
   const [donations, setDonations] = useState([]);
+  const [isDesktop, setIsDesktop] = useState(
+    window.matchMedia("(min-width: 1024px)").matches
+  );
+  const [startIndex, setStartIndex] = useState(0);
 
   useEffect(() => {
     const getDonationListData = async () => {
@@ -46,17 +76,59 @@ export default function DonationList() {
     getDonationListData();
   }, []);
 
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 1024px)");
+    const handleResize = (e) => setIsDesktop(e.matches);
+
+    mediaQuery.addEventListener("change", handleResize);
+    return () => {
+      mediaQuery.removeEventListener("change", handleResize);
+    };
+  }, []);
+
+  const handleRightClick = () => {
+    if (startIndex + itemsPerPage < donations.length) {
+      setStartIndex((prev) => prev + itemsPerPage);
+    }
+  };
+  const handleLeftClick = () => {
+    if (startIndex - itemsPerPage >= 0) {
+      setStartIndex((prev) => prev - itemsPerPage);
+    }
+  };
+
+  const visibleDonations = donations.slice(
+    startIndex,
+    startIndex + itemsPerPage
+  );
+
   return (
     <DonationFlexListWrap>
       <h1>후원을 기다리는 조공</h1>
       <DonationFlexList>
-        <RightDiv />
-        {donations.map((donation) => (
+        {isDesktop ? (
+          startIndex === 0 || (
+            <LeftButton onClick={handleLeftClick}>
+              <img src={leftBtnImg} />
+            </LeftButton>
+          )
+        ) : (
+          <RightDiv />
+        )}
+        {visibleDonations.map((donation) => (
           <DonationLi key={donation.id}>
             <Donation donation={donation} />
           </DonationLi>
         ))}
-        <RightDiv />
+        {isDesktop ? (
+          startIndex + itemsPerPage >= donations.length || (
+            <RightButton onClick={handleRightClick}>
+              <img src={rightBtnImg} />
+            </RightButton>
+          )
+        ) : (
+          <RightDiv />
+        )}
       </DonationFlexList>
     </DonationFlexListWrap>
   );

--- a/src/pages/myPage/components/MyPageIdolList.jsx
+++ b/src/pages/myPage/components/MyPageIdolList.jsx
@@ -2,9 +2,10 @@ import styled from "styled-components";
 import IdolCircle from "../../../components/IdolCircle";
 
 const TotalIdolList = styled.ul`
-  margin-bottom:48px;
-  display:flex; gap:32px 22px;
-`
+  margin-bottom: 48px;
+  display: flex;
+  gap: 32px 22px;
+`;
 
 //get http 요청으로 아이돌 불러오기
 const fetchMockIdol = async () => {
@@ -13,14 +14,12 @@ const fetchMockIdol = async () => {
   );
   if (!response.ok) return;
   const data = await response.json();
-  console.log(data);
   const idols = data.list;
   return idols;
 };
 const mockIdols = await fetchMockIdol();
 
 export default function SelectedIdol() {
-
   return (
     <div>
       <TotalIdolList>

--- a/src/utils/idolApi.js
+++ b/src/utils/idolApi.js
@@ -97,3 +97,24 @@ export const fetchDeleteIdol = async (id) => {
     console.error("IDOL 삭제 요청 실패", error);
   }
 };
+
+export const fetchChartDataByGender = async (gender, option) => {
+  const { cursor, pageSize } = option;
+  const params = new URLSearchParams();
+
+  if (cursor) params.append("cursor", cursor);
+  if (pageSize) params.append("pageSize", pageSize);
+
+  const queryString = params.toString();
+  const url = `${BASE_URL}/charts/{gender}?gender=${gender}&${
+    queryString ? `${queryString}` : ""
+  }`;
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP 오류: ${response.status}`);
+    return await response.json();
+  } catch (error) {
+    console.error("차트 불러오기 실패", error);
+  }
+};

--- a/src/utils/mediaHelper.js
+++ b/src/utils/mediaHelper.js
@@ -1,0 +1,20 @@
+import { css } from 'styled-components';
+
+// Breakpoints 정의 (px 단위)
+const breakpoints = {
+  mobile: 576,
+  tablet: 768,
+  desktop: 1024,
+};
+
+// 미디어 쿼리 헬퍼 함수
+const media = Object.keys(breakpoints).reduce((acc, label) => {
+  acc[label] = (...args) => css`
+    @media (min-width: ${breakpoints[label]}px) {
+      ${css(...args)}
+    }
+  `;
+  return acc;
+}, {});
+
+export default media;


### PR DESCRIPTION
## 구현사항
- 페이지의 반응형 디자인 구현 완료
- 성별에 따른 아이돌 목록 불러오는 api함수 구현 후 연결
### 데스크톱
- 데스크톱 사이즈의 페이지 일 때 후원목록 버튼으로 조작
- 차트 레이아웃 2줄로 변경 grid 사용
- 그외 미세한 조정 
### 태블릿, 모바일 
- 기타 반응형 구현완료
- 후원 목록 좌우 스크롤시 더미 div를 끼워 이전에 스크롤 하던 기능을 좀 더 간편하게 해결하려고 함
## 참고자료
### 모바일
![스크린샷 2025-03-12 오후 5 23 44](https://github.com/user-attachments/assets/7ef14905-d4de-4320-9bb7-370599d8aef1)
### 태블릿
![스크린샷 2025-03-12 오후 5 24 06](https://github.com/user-attachments/assets/7b35cbe3-29b3-46eb-9de4-872b8514d797)
### 데스크톱
![스크린샷 2025-03-12 오후 5 24 21](https://github.com/user-attachments/assets/1b2a738a-1ab7-4232-bff3-84d802dad460)
